### PR TITLE
add -std=c++03 to rate4site makefile

### DIFF
--- a/3rd party software/rate4site.3.2.source_fast/sourceMar09/Makefile
+++ b/3rd party software/rate4site.3.2.source_fast/sourceMar09/Makefile
@@ -10,7 +10,7 @@ CXX= g++
 CC=$(CXX)
 
 #LDFLAGS =  -mips4 -Wl,-rpath,/opt/lib
-CXXFLAGS += -O3 -Wno-deprecated
+CXXFLAGS += -O3 -std=c++03 -Wno-deprecated
 Libsources= AddLog.cpp NNiProp.cpp NNiSep.cpp Nni.cpp aaJC.cpp						\
 allTrees.cpp allTreesSeparateModel.cpp alphabet.cpp amino.cpp						\
    bestAlpha.cpp bestAlphaManyTrees.cpp bestHKYparam.cpp bootstrap.cpp					\

--- a/3rd party software/rate4site.3.2.source_fast/sourceMar09/Makefile_slow
+++ b/3rd party software/rate4site.3.2.source_fast/sourceMar09/Makefile_slow
@@ -10,7 +10,7 @@ CXX= g++
 CC=$(CXX)
 
 #LDFLAGS =  -mips4 -Wl,-rpath,/opt/lib
-CXXFLAGS += -O3 -Wno-deprecated -DDOUBLEREP
+CXXFLAGS += -O3 -std=c++03 -Wno-deprecated -DDOUBLEREP
 Libsources= AddLog.cpp NNiProp.cpp NNiSep.cpp Nni.cpp aaJC.cpp						\
 allTrees.cpp allTreesSeparateModel.cpp alphabet.cpp amino.cpp						\
    bestAlpha.cpp bestAlphaManyTrees.cpp bestHKYparam.cpp bootstrap.cpp					\

--- a/3rd party software/rate4site.3.2.source_slow/sourceMar09/Makefile
+++ b/3rd party software/rate4site.3.2.source_slow/sourceMar09/Makefile
@@ -10,7 +10,7 @@ CXX= g++
 CC=$(CXX)
 
 #LDFLAGS =  -mips4 -Wl,-rpath,/opt/lib
-CXXFLAGS += -O3 -Wno-deprecated -DDOUBLEREP
+CXXFLAGS += -O3 -std=c++03 -Wno-deprecated -DDOUBLEREP
 Libsources= AddLog.cpp NNiProp.cpp NNiSep.cpp Nni.cpp aaJC.cpp						\
 allTrees.cpp allTreesSeparateModel.cpp alphabet.cpp amino.cpp						\
    bestAlpha.cpp bestAlphaManyTrees.cpp bestHKYparam.cpp bootstrap.cpp					\

--- a/3rd party software/rate4site.3.2.source_slow/sourceMar09/Makefile_fast
+++ b/3rd party software/rate4site.3.2.source_slow/sourceMar09/Makefile_fast
@@ -10,7 +10,7 @@ CXX= g++
 CC=$(CXX)
 
 #LDFLAGS =  -mips4 -Wl,-rpath,/opt/lib
-CXXFLAGS += -O3 -Wno-deprecated
+CXXFLAGS += -O3 -std=c++03 -Wno-deprecated
 Libsources= AddLog.cpp NNiProp.cpp NNiSep.cpp Nni.cpp aaJC.cpp						\
 allTrees.cpp allTreesSeparateModel.cpp alphabet.cpp amino.cpp						\
    bestAlpha.cpp bestAlphaManyTrees.cpp bestHKYparam.cpp bootstrap.cpp					\


### PR DESCRIPTION
this makes it possible to still compile rate4site on modern systems